### PR TITLE
Updated templates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,8 +132,7 @@ All the above examples will generate the following markup:
                   ,https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_720/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040&h=585 767w
                   ,https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_990/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040&h=585 1030w"
       data-src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040&h=585" 
-      sizes="100vw"
-      alt="test"
+      alt="Operational dashboard"
       width="1040"
       height="585"
       class="lazyload"
@@ -141,7 +140,11 @@ All the above examples will generate the following markup:
     
     <noscript>
       <img
-        src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040&h=585"
+        srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_412/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040&h=585 460w
+                ,https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_572/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040&h=585 620w
+                ,https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_720/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040&h=585 767w
+                ,https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_990/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040&h=585 1030w"
+        src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto/https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040&h=585" 
         alt="Operational dashboard"
         width="1040"
         height="585"

--- a/canonicalwebteam/templates/image_template.html
+++ b/canonicalwebteam/templates/image_template.html
@@ -4,7 +4,6 @@
               {% if width > 720 %},https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_720/https://assets.ubuntu.com/{{ path }} 767w{% endif %}
               {% if width > 990 %},https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_990/https://assets.ubuntu.com/{{ path }} 1030w{% endif %}"
   data-src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto/https://assets.ubuntu.com/{{ path }}"
-  data-sizes="100vw"
   alt="{{ alt }}"
   width="{{ width }}"
   height="{{ height }}"
@@ -18,7 +17,6 @@
             {% if width > 720 %},https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_720/https://assets.ubuntu.com/{{ path }} 767w{% endif %}
             {% if width > 990 %},https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_990/https://assets.ubuntu.com/{{ path }} 1030w{% endif %}"
     src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto/https://assets.ubuntu.com/{{ path }}"
-    sizes="100vw"
     alt="{{ alt }}"
     width="{{ width }}"
     height="{{ height }}"

--- a/canonicalwebteam/templates/image_template.html
+++ b/canonicalwebteam/templates/image_template.html
@@ -4,8 +4,8 @@
               {% if width > 720 %},https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_720/https://assets.ubuntu.com/{{ path }} 767w{% endif %}
               {% if width > 990 %},https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_990/https://assets.ubuntu.com/{{ path }} 1030w{% endif %}"
   data-src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto/https://assets.ubuntu.com/{{ path }}"
-  sizes="100vw"
-  alt="test"
+  data-sizes="100vw"
+  alt="{{ alt }}"
   width="{{ width }}"
   height="{{ height }}"
   class="lazyload"
@@ -13,7 +13,12 @@
 
 <noscript>
   <img
+    srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_412/https://assets.ubuntu.com/{{ path }} 460w
+            {% if width > 572 %},https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_572/https://assets.ubuntu.com/{{ path }} 620w{% endif %}
+            {% if width > 720 %},https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_720/https://assets.ubuntu.com/{{ path }} 767w{% endif %}
+            {% if width > 990 %},https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_990/https://assets.ubuntu.com/{{ path }} 1030w{% endif %}"
     src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto/https://assets.ubuntu.com/{{ path }}"
+    sizes="100vw"
     alt="{{ alt }}"
     width="{{ width }}"
     height="{{ height }}"


### PR DESCRIPTION
- `data-sizes` for lazy sizes
- `srcset` and `sizes` for noscript
-  correct `alt` for lazy sizes