### PR TITLE
Support for attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 canonicalwebteam.image_template.egg-info
 __pycache__
+env*/

--- a/canonicalwebteam/image_template/__init__.py
+++ b/canonicalwebteam/image_template/__init__.py
@@ -12,7 +12,7 @@ env = Environment(loader=FileSystemLoader(parent_dir + "/templates"))
 template = env.get_template("image_template.html")
 
 
-def image_template(path, alt, width, height):
+def image_template(path, alt, width, height, attributes={}):
     """
     Generate image markup
     """
@@ -26,10 +26,23 @@ def image_template(path, alt, width, height):
     query["w"] = int(width)
     query["h"] = int(height)
 
-    path = path.lstrip("/") + "?" + urlencode(query, doseq=True)
+    # Split out classes from attributes
+    # As we need to handle them specially
+    extra_classes = None
+
+    if "class" in attributes:
+        extra_classes = attributes["class"]
+        del attributes["class"]
+
+    path = parse_result.path.lstrip("/") + "?" + urlencode(query, doseq=True)
 
     return template.render(
-        path=path, alt=alt, width=int(width), height=int(height)
+        path=path,
+        alt=alt,
+        width=int(width),
+        height=int(height),
+        extra_classes=extra_classes,
+        attributes=attributes,
     )
 
 

--- a/canonicalwebteam/templates/image_template.html
+++ b/canonicalwebteam/templates/image_template.html
@@ -1,8 +1,14 @@
 <img 
   data-srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_412/https://assets.ubuntu.com/{{ path }} 460w
-              {% if width > 572 %},https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_572/https://assets.ubuntu.com/{{ path }} 620w{% endif %}
-              {% if width > 720 %},https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_720/https://assets.ubuntu.com/{{ path }} 767w{% endif %}
-              {% if width > 990 %},https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_990/https://assets.ubuntu.com/{{ path }} 1030w{% endif %}"
+{%- if width > 572 %}
+               ,https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_572/https://assets.ubuntu.com/{{ path }} 620w
+{%- endif %}
+{%- if width > 720 %}
+               ,https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_720/https://assets.ubuntu.com/{{ path }} 767w
+{%- endif %}
+{%- if width > 990 %}
+               ,https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_990/https://assets.ubuntu.com/{{ path }} 1030w
+{%- endif %}"
   data-src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto/https://assets.ubuntu.com/{{ path }}"
   alt="{{ alt }}"
   width="{{ width }}"
@@ -16,9 +22,15 @@
 <noscript>
   <img
     srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_412/https://assets.ubuntu.com/{{ path }} 460w
-            {% if width > 572 %},https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_572/https://assets.ubuntu.com/{{ path }} 620w{% endif %}
-            {% if width > 720 %},https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_720/https://assets.ubuntu.com/{{ path }} 767w{% endif %}
-            {% if width > 990 %},https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_990/https://assets.ubuntu.com/{{ path }} 1030w{% endif %}"
+  {%- if width > 572 %}
+            ,https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_572/https://assets.ubuntu.com/{{ path }} 620w
+  {%- endif %}
+  {%- if width > 720 %}
+            ,https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_720/https://assets.ubuntu.com/{{ path }} 767w
+  {%- endif %}
+  {%- if width > 990 %}
+            ,https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_990/https://assets.ubuntu.com/{{ path }} 1030w
+  {%- endif %}"
     src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto/https://assets.ubuntu.com/{{ path }}"
     alt="{{ alt }}"
     width="{{ width }}"

--- a/canonicalwebteam/templates/image_template.html
+++ b/canonicalwebteam/templates/image_template.html
@@ -7,7 +7,10 @@
   alt="{{ alt }}"
   width="{{ width }}"
   height="{{ height }}"
-  class="lazyload"
+  class="lazyload{% if extra_classes %} {{ extra_classes }}{% endif %}"
+{%- for attr_name, attr_value in attributes.items() %}
+  {{ attr_name }}="{{ attr_value }}"
+{%- endfor %}
 />
 
 <noscript>
@@ -20,5 +23,11 @@
     alt="{{ alt }}"
     width="{{ width }}"
     height="{{ height }}"
+{%- if extra_classes %}
+    class="{{ extra_classes }}"
+{%- endif %}
+{%- for attr_name, attr_value in attributes.items() %}
+    {{ attr_name }}="{{ attr_value }}"
+{%- endfor %}
   />
 </noscript>


### PR DESCRIPTION
QA
--

E.g.:

``` bash
python3 -m venv env3
source env3/bin/activate
pip install .
python3 -c 'from canonicalwebteam import image_template; print(image_template(path="/v1/fish.png?fmt=jpg", alt="rt", width=345, height=211, attributes={"class": "shutup luke", "id": "fool"}))'
```

Check you see custom attributes, and that classes get successfully merged with the `lazyload` class:

``` html
<img
  data-srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_412/https://assets.ubuntu.com/v1/fish.png?fmt=jpg&w=345&h=211 460w


              "
  data-src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto/https://assets.ubuntu.com/v1/fish.png?fmt=jpg&w=345&h=211"
  alt="rt"
  width="345"
  height="211"
  class="lazyload shutup luke"
  id="fool"
/>

<noscript>
  <img
    srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_412/https://assets.ubuntu.com/v1/fish.png?fmt=jpg&w=345&h=211 460w


            "
    src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto/https://assets.ubuntu.com/v1/fish.png?fmt=jpg&w=345&h=211"
    alt="rt"
    width="345"
    height="211"
    class="shutup luke"
    id="fool"
  />
</noscript>
```